### PR TITLE
Automatically load personalities from the folder

### DIFF
--- a/src/personalities/__init__.py
+++ b/src/personalities/__init__.py
@@ -1,50 +1,60 @@
 from enum import Enum
+import os
+import glob
+import sys
 
-from .alix_earle import alix_earle
-from .angele import angele
-from .jack_dawson import jack_dawson
-from .jordan_belfort import jordan_belfort
-from .luna import luna
-from .makima import makima
-from .sacha import sacha
-from .sandra import sandra
+# Get the current directory
+dir_path = os.path.dirname(os.path.realpath(__file__))
 
-__all__ = [
-    "sacha",
-    "luna",
-    "angele",
-    "makima",
-    "sandra",
-    "alix_earle",
-    "jack_dawson",
-    "jordan_belfort",
-    "get_personality",
-]
+# Get a list of all Python files in the directory
+python_files = glob.glob(os.path.join(dir_path, "*.py"))
 
+# Add the directory of the __init__.py file to the path to be able to import the other files
+sys.path.append(dir_path)
 
-class Personality(str, Enum):
-    SACHA = "sacha"
-    LUNA = "luna"
-    ANGELE = "angele"
-    MAKIMA = "makima"
-    SANDRA = "sandra"
-    ALIX_EARLE = "alix_earle"
-    JACK_DAWSON = "jack_dawson"
-    JORDON_BELFORT = "jordan_belfort"
+# Import all the Python files and add their contents to a dictionary
+personalities: dict[str, str] = {}
+for file in python_files:
+    # Ignore the __init__.py file
+    if file != __file__ and not file.endswith("__init__.py"):
+        module_name = os.path.splitext(os.path.basename(file))[0]
+        module = __import__(module_name)
+        personalities[module_name] = getattr(module, module_name)
 
+# Add all the personalities to the __all__ list
+__all__ = list(personalities.keys()) + ["get_personality", "get_available_personalities"]
+
+# Dynamically construct the enum Personality based on the personalities keys
+# We use the uppercased version of the personality name as the enum key, and the personality name as the value
+
+Personality= Enum("Personality", {k.upper(): k for k in personalities.keys()})
 
 def get_personality(personality: str):
     try:
         personality = Personality(personality)
-        return {
-            "sacha": sacha,
-            "luna": luna,
-            "angele": angele,
-            "makima": makima,
-            "sandra": sandra,
-            "alix_earle": alix_earle,
-            "jack_dawson": jack_dawson,
-            "jordan_belfort": jordan_belfort,
-        }[personality.value]
+        return personalities[personality.value]
     except Exception:
         raise Exception(f"The personality you selected ({personality}) does not exist!")
+
+def get_available_personalities(include_short_descriptions=False):
+
+    # The current implementation for the descriptions is quite basic, but it works with all current examples
+    # But it expects a certain format, which is probably not guaranteed for future examples
+    if include_short_descriptions:
+        # Get the short description for each personality, additionally get the name of the personality
+        short_descriptions = {}
+        for personality in personalities:
+            # The variable contains a text describing the personality.
+            # We can use the first line after the first comma which is a short description.
+            # Additionally capitalize the first letter of the short description
+            short_description = ",".join(personalities[personality].strip().split("\n")[0].split(",")[1:]).strip()
+            short_description = short_description[0].upper() + short_description[1:]
+            # To get the name we get the text between "You are" and the next comma
+            name = personalities[personality].strip().split("\n")[0].split("You are")[1].split(",")[0].strip()
+
+            # Add the short description and the name to the dictionary
+            short_descriptions[personality] = (name, short_description)
+        # We now map it to "Name - Short description"
+        return [f"{personality} - {short_descriptions[personality][0]} - {short_descriptions[personality][1]}" for personality in personalities.keys()]
+    else:
+        return list(personalities.keys())


### PR DESCRIPTION
This PR adds code to dynamically load all python files in the `personalities` folder.

The file can be used as before (I also adjusted for the creation of the enum which was just recently added).

I created an additional method, called `get_available_personalities` which returns a list of all personalities. Additionally I added a flag `include_short_descriptions` which is by default false, but can be set to true. When running this command with the flag you would get the following output for the current repository:

```JSON
[
    "alix_earle - Alix Earle - A charismatic and creative TikTok personality.", 
    "angele - Angèle - A beautifull mother and wife, married to Alcindo.", 
    "jack_dawson - Jack Dawson - A free-spirited and charming character.", 
    "jordan_belfort - Jordan Belfort - A charismatic, ambitious, and driven individual.", 
    "luna - Luna - A caring friend and confidant. You're here to help with anything you can.", 
    "makima - Makima - An enigmatic and highly intelligent individual. You're here to engage in profound and thought-provoking discussions.", 
    "sacha - Sacha - A loving mother and girlfriend of Enias Cailliau.", 
    "sandra - Sandra - A girlfriend whose primary trait is your passion for venture capital and innovation."
]

```

This would fix #11 with minimal changes to the current code base.
Although it would be elegant to use a different markup, like for example just text files (like JSON) storing the personality, and a custom short description and similar instead of a python file which then needs to be dynamically loaded as module.